### PR TITLE
Pin down source versions

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -9,22 +9,34 @@
   <remote fetch="https://github.com/embeddedarm" name="ts" />
   <remote fetch="git://github.com/meta-qt5/" name="qt5" />
 
-  <project remote="yocto" revision="morty" name="poky" path="sources/poky"/>
-  <project remote="yocto" revision="morty" name="meta-freescale" path="sources/meta-freescale"/>
+  <project remote="yocto" name="poky" path="sources/poky"
+           revision="924e576b8930fd2268d85f0b151e5f68a3c2afce" upstream="morty"/>
 
-  <project remote="oe" revision="morty" name="meta-openembedded" path="sources/meta-openembedded"/>
+  <project remote="yocto" name="meta-freescale" path="sources/meta-freescale"
+           revision="a398b50b7fc084a9e68cc3000c218d5028522a25" upstream="morty"/>
 
-  <project remote="freescale" revision="morty" name="fsl-community-bsp-base" path="sources/base">
+  <project remote="oe" name="meta-openembedded" path="sources/meta-openembedded"
+           revision="fe5c83312de11e80b85680ef237f8acb04b4b26e" upstream="morty"/>
+
+  <project remote="freescale" name="fsl-community-bsp-base" path="sources/base"
+           revision="0b9b4db05ec6a5d96f3a6292f6c94aa963238b11" upstream="morty">
 	<linkfile dest="README" src="README"/>
 	<linkfile dest="setup-environment" src="setup-environment"/>
   </project>
 
-  <project remote="freescale" revision="morty" name="meta-freescale-3rdparty" path="sources/meta-freescale-3rdparty"/>
-  <project remote="freescale" revision="morty" name="meta-freescale-distro" path="sources/meta-freescale-distro"/>
-  <project remote="freescale" revision="morty" name="Documentation" path="sources/Documentation"/>
+  <project remote="freescale" name="meta-freescale-3rdparty" path="sources/meta-freescale-3rdparty"
+           revision="d31308389508945bd4432a6f0213c27eacf6a1b8" upstream="morty"/>
 
-  <project remote="ts" revision="morty" name="meta-ts" path="sources/meta-ts"/>
+  <project remote="freescale" name="meta-freescale-distro" path="sources/meta-freescale-distro"
+           revision="cd5c7a2539f40004f74126e9fdf08254fd9a6390" upstream="morty"/>
 
-  <project remote="qt5" revision="morty" name="meta-qt5" path="sources/meta-qt5"/>
+  <project remote="freescale" name="Documentation" path="sources/Documentation"
+           revision="4e92d8509dd5b4489549ee61f2c6809e0e0cb04c" upstream="morty"/>
+
+  <project remote="ts" name="meta-ts" path="sources/meta-ts"
+           revision="5ff02ccd025e27f031a8c970eb5323a6a7ede9a0" upstream="morty"/>
+
+  <project remote="qt5" name="meta-qt5" path="sources/meta-qt5"
+           revision="3601fd2c5306ac6d5d0d536e0be8cbb90da9b4c1" upstream="morty"/>
 
 </manifest>


### PR DESCRIPTION
This allows the build to be repeatable, requiring updates to be made
on purpose.