### PR TITLE
Add build-essential

### DIFF
--- a/local.conf
+++ b/local.conf
@@ -34,6 +34,7 @@ IMAGE_INSTALL_append = " \
     qtsvg \
     qtquickcontrols \
     \
+    packagegroup-core-buildessential \
     packagegroup-core-boot \
     packagegroup-core-eclipse-debug \
     packagegroup-core-full-cmdline \


### PR DESCRIPTION
Enables pip to install dependencies that must be compiled by gcc,
including pymodbus and its dependencies.