### PR TITLE
Add Qt Virtual Keyboard

### DIFF
--- a/local.conf
+++ b/local.conf
@@ -33,10 +33,10 @@ IMAGE_INSTALL_append = " \
     qtserialport \
     qtsvg \
     qtquickcontrols \
+    qtvirtualkeyboard \
     \
     packagegroup-core-buildessential \
     packagegroup-core-boot \
-    packagegroup-core-eclipse-debug \
     packagegroup-core-full-cmdline \
     packagegroup-core-tools-debug \
     packagegroup-machine-base \


### PR DESCRIPTION
The Qt Virtual Keyboard is needed for the next iteration of the UX
design.  Also removed eclipse debug package because it was adding a
minute and a half to shutdown time.