### PR TITLE
Update meta-ts layer

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -34,7 +34,7 @@
            revision="4e92d8509dd5b4489549ee61f2c6809e0e0cb04c" upstream="morty"/>
 
   <project remote="ts" name="meta-ts" path="sources/meta-ts"
-           revision="5ff02ccd025e27f031a8c970eb5323a6a7ede9a0" upstream="morty"/>
+           revision="5c499dd57813911f5190043ac45a112089156a49" upstream="morty"/>
 
   <project remote="qt5" name="meta-qt5" path="sources/meta-qt5"
            revision="3601fd2c5306ac6d5d0d536e0be8cbb90da9b4c1" upstream="morty"/>


### PR DESCRIPTION
Brings the meta-ts layer to the current head of the morty branch.
This includes some changes that will be required to get board rev C
WiFi to work properly.