### PR TITLE
Add Qt Quick Controls 2 to the Yocto build

### DIFF
--- a/local.conf
+++ b/local.conf
@@ -33,6 +33,7 @@ IMAGE_INSTALL_append = " \
     qtserialport \
     qtsvg \
     qtquickcontrols \
+    qtquickcontrols2 \
     qtvirtualkeyboard \
     \
     packagegroup-core-buildessential \


### PR DESCRIPTION
This component is needed to provide a later version of StackView to
applications that use this platform.